### PR TITLE
Add /item/tokens/query handler to retrieve all items and their query …

### DIFF
--- a/assets/itemsAndTokens.txt
+++ b/assets/itemsAndTokens.txt
@@ -23,7 +23,6 @@ adzuki beans:adzuki,beans
 agar:agar
 agar agar:agar,agar
 agave:agave
-agave bectar:agave,bectar
 agave nectar:agave,nectar
 agave syrup:agave,syrup
 agricole:agricole

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ func main() {
 	r.HandleFunc("/user/delete", userDeleteHandler)
 	r.HandleFunc("/user/query", userQueryHandler)
 	r.HandleFunc("/item/query", itemQueryHandler)
+	r.HandleFunc("/item/tokens/query", itemTokensQueryHandler)
 	r.HandleFunc("/store/query", storeQueryHandler)
 	r.HandleFunc("/store/add", storeAddHandler)
 	r.HandleFunc("/report/upload", reportUploadHandler)
@@ -87,6 +88,18 @@ func itemQueryHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	status, err := QueryItems(ctx, w, r)
+	if err != nil {
+		http.Error(w, err.Error(), status)
+	}
+}
+
+func itemTokensQueryHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := context.Background()
+	if r.Method != "POST" {
+		http.NotFound(w, r)
+		return
+	}
+	status, err := QueryItemTokens(ctx, w, r)
 	if err != nil {
 		http.Error(w, err.Error(), status)
 	}


### PR DESCRIPTION
…tokens from server.

* Why?

We want a preset and comprehensive list of items for users to query and report so that all users
see the same items and don't report malformed items.

To ease autocompletion for the user, the server responds with tokens. If the user enters a
string that is contained in one of the tokens, the item is provided for the user to query and report.

* Response memory size is about 278 KB.
```bash
$ curl -d '{"user_id":"b94d8836-5e88-4232-ad55-b214f1e7f9e1"}' -H "Content-Type: application/json" -X POST http://localhost:8080/item/tokens/query > /tmp/resp
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  278k    0  278k  100    50  20.9M   3846 --:--:-- --:--:-- --:--:-- 20.9M
```

* Example response snippet
```json
[
  ...
  {
    "name": "allspice liqueur",
    "tokens": [
      "allspice",
      "liqueur"
    ]
  },
  {
    "name": "almond",
    "tokens": [
      "almond"
    ]
  },
  {
    "name": "almond argan butter",
    "tokens": [
      "almond",
      "argan",
      "butter"
    ]
  },
  ...
]
```