### PR TITLE
Users see 4XX error if they add a store that already exists in storage 

### DIFF
--- a/item.go
+++ b/item.go
@@ -52,7 +52,7 @@ func init() {
 // ******************************************
 
 type QueryItemTokensReq struct {
-	UserID string `json:"user_id"`
+	UserID string `json:"userID"`
 }
 
 type QueryItemTokensResp []*ItemTokenInfo

--- a/item.go
+++ b/item.go
@@ -52,7 +52,7 @@ func init() {
 // ******************************************
 
 type QueryItemTokensReq struct {
-	UserID string `json:"userID"`
+	UserID string `json:"user_id"`
 }
 
 type QueryItemTokensResp []*ItemTokenInfo


### PR DESCRIPTION
This is done by having the store id be the places API id rather than a randomly generated uuid.